### PR TITLE
Observer -> clearApc() added function check for 'apc_clear_cache'

### DIFF
--- a/app/code/community/Buric/Apc/Model/Observer.php
+++ b/app/code/community/Buric/Apc/Model/Observer.php
@@ -10,7 +10,7 @@
 class Buric_Apc_Model_Observer {
 
     public function clearApc() {
-        return apc_clear_cache() && apc_clear_cache('user') && apc_clear_cache('opcode');
+        return function_exists('apc_clear_cache') && apc_clear_cache() && apc_clear_cache('user') && apc_clear_cache('opcode');
     }
 
     public function injectHtml(Varien_Event_Observer $observer) {


### PR DESCRIPTION
Observer -> clearApc() added function check for 'apc_clear_cache'

This is needed because events 'controller_action_postdispatch_adminhtml_cache_flushAll' and 'controller_action_postdispatch_adminhtml_cache_flushSystem' have no check for this unlike the 'Flush APC Cache' Button
